### PR TITLE
Add Latvian character accents to the default whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Inspired from [Highlight Bad Chars](https://github.com/WengerK/vscode-highlight-
 
 You can override the whitelist of characters that will not be highlighted in your workspace or user settings:
 ```
-"highlight-dodgy-characters.whitelist": "´€£¡¿äàáâãåǎąăæçćĉčđďðèéêëěęĝģğĥìíîïıĵķĺļłľñńňöòóôõőøœŕřẞßśŝşšșťţþțüùúûűũųůŵýÿŷźžż"
+"highlight-dodgy-characters.whitelist": "´€£¡¿äàáâãåǎąăāæçćĉčđďðèéêëěęēĝģğĥìíîïīıĵķĺļłľñńňņöòóôõőōøœŕřẞßśŝşšșťţþțüùúûűũūųůŵýÿŷźžż"
 ```
 
 ### Examples

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
             "string",
             "null"
           ],
-          "default": "´€£¡¿äàáâãåǎąăæçćĉčđďðèéêëěęĝģğĥìíîïıĵķĺļłľñńňöòóôõőøœŕřẞßśŝşšșťţþțüùúûűũųůŵýÿŷźžż",
+          "default": "´€£¡¿äàáâãåǎąăāæçćĉčđďðèéêëěęēĝģğĥìíîïīıĵķĺļłľñńňņöòóôõőōøœŕřẞßśŝşšșťţþțüùúûűũūųůŵýÿŷźžż",
           "description": "Specifies the whitelisted characters that should not be highlighted."
         }
       }

--- a/src/test/examples.txt
+++ b/src/test/examples.txt
@@ -31,6 +31,6 @@ Things this plugin doesn't highlight (whitelisted by default):
 - Sharp s: ẞß
 - Inverted punctuation: ¡¿
 - Characters with accents: 
-ÄäÀàÁáÂâÃãÅåǍǎĄąĂăÆæÇçĆćĈĉČčĎđĐďðÈèÉéÊêËëĚěĘęĜĝĢģĞğĤĥÌìÍíÎîÏïıĴĵĶķĹĺĻļŁłĽľÑñŃńŇňÖöÒòÓóÔôÕõŐőØøŒœŔŕŘřẞßŚśŜŝŞşŠšȘșŤťŢţÞþȚțÜüÙùÚúÛûŰűŨũŲųŮůŴŵÝýŸÿŶŷŹźŽžŻż
- 
+ÄäÀàÁáÂâÃãÅåǍǎĄąĂăĀāÆæÇçĆćĈĉČčĎđĐďðÈèÉéÊêËëĚěĘęĒēĜĝĢģĞğĤĥÌìÍíÎîÏïĪīıĴĵĶķĹĺĻļŁłĽľÑñŃńŇňŅņÖöÒòÓóÔôÕõŐőŌōØøŒœŔŕŘřẞßŚśŜŝŞşŠšȘșŤťŢţÞþȚțÜüÙùÚúÛûŰűŨũŲųŪūŮůŴŵÝýŸÿŶŷŹźŽžŻż
+
 You can whitelist characters you don't wish to highlight in the settings


### PR DESCRIPTION
New characters: `āēīōūņ`

With this all valid Latvian characters are whitelisted (some like `šžč` already was). Some characters are more widely used as well, such as Ū in Lithuanian. None of the new characters are visually indistinguishable from normal ascii chars.