### PR TITLE
Fix project description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "highlight-dodgy-characters",
   "displayName": "Highlight Dodgy Characters",
-  "description": "Highlight all non-unicode characters",
+  "description": "Highlight all non-ASCII characters",
   "version": "0.4.3",
   "publisher": "nachocab",
   "engines": {


### PR DESCRIPTION
The README was updated in 353687c to say "non-ascii" instead of "non-unicode", but the description is still incorrect in the VSCode extension marketplace. This PR fixes the project description.

Note that the repository tagline here on github still needs to be changed:

<img width="631" alt="Screenshot 2019-11-26 at 18 40 31" src="https://user-images.githubusercontent.com/478237/69662494-608c0680-107c-11ea-9ab5-f7e481e67546.png">
